### PR TITLE
Install recipes only for deployer 6 and earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This action makes it easy to deploy your php services using [Github Actions](htt
 * Starts the `ssh-agent`
 * Loads your deployment SSH private key into the agent
 * Configures `known_hosts` with your provided key (or turns of SSH host key checking)
-* Installs deployer
+* Installs deployer & deployer recipes
 
 ## Using the action
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     deployer-version:
         description: 'Version of deployer to install'
         required: false
+    deployer-recipes-version:
+        description: 'Version of deployer recipes to install'
+        required: false
     deployer-skip-install:
         description: 'Skip install of deployer (if you are using a locally installed version)'
         required: false

--- a/src/SetupDeployer.ts
+++ b/src/SetupDeployer.ts
@@ -3,7 +3,17 @@ const core = require('@actions/core');
 
 interface DeployerOptions {
     deployerVersion?: string,
+    deployerRecipesVersion?: string,
     skipDeployerInstall?: string,
+}
+
+const getInstalledDeployerMajorVersion = async (): Promise<number|null> => {
+    const {stdout} = await execa('composer', ['global', 'show', 'deployer/deployer']);
+
+    const regexp = /^versions.*?(\d+)/im;
+    const matches = regexp.exec(stdout);
+
+    return matches && +matches[1];
 }
 
 export default async (options: DeployerOptions): Promise<void> => {
@@ -14,6 +24,16 @@ export default async (options: DeployerOptions): Promise<void> => {
         : 'deployer/deployer';
 
     await execa('composer', ['global', 'require', deployerPackage]);
+
+    const deployerMajor = await getInstalledDeployerMajorVersion();
+
+    if (deployerMajor && deployerMajor <= 6) {
+        const deployerRecipesPackage = options.deployerRecipesVersion
+            ? `deployer/recipes:${options.deployerRecipesVersion}`
+            : 'deployer/recipes';
+
+        await execa('composer', ['global', 'require', deployerRecipesPackage]);
+    }
 
     const installPath = (await execa('composer', ['global', 'config', 'home'])).stdout;
     core.addPath(`${installPath}/vendor/bin`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ const tasks = new taskz([
         text: 'Install Deployer',
         task: () => SetupDeployer({
             deployerVersion: core.getInput('deployer-version'),
+            deployerRecipesVersion: core.getInput('deployer-recipes-version'),
             skipDeployerInstall: core.getInput('deployer-skip-install'),
         })
     },


### PR DESCRIPTION
Reverted to the deployer/recipes package installation. 

Fix for issue #10 