### PR TITLE
feat: Bump Node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
         description: 'Skip install of deployer (if you are using a locally installed version)'
         required: false
 runs:
-    using: 'node12'
+    using: 'node20'
     main: 'dist/index.js'
 branding:
     icon: server


### PR DESCRIPTION
Bump node version to latest LTS release to suppress the runtime warnings.
Should be zero risk behind the change, since GH forces Node20 at runtime anyway.

<img width="1353" alt="image" src="https://github.com/user-attachments/assets/f3a5bcd4-f515-4643-b148-c125908e2130">

Fixes: #26 